### PR TITLE
fix typo on ImageMagick

### DIFF
--- a/README.org
+++ b/README.org
@@ -54,10 +54,10 @@ Feel free to send PR!
 *** make
 ~make~ runs ~make $(DIRS)~ and ~make headers~ that prepare dirs and create headers.
 
-This Makefile require ~imageMagic~ and ~mustache~.
+This Makefile require ~ImageMagick~ and ~mustache~.
 
 #+begin_src bash
-  brew install imagemagic
+  brew install imagemagick
   gem install mustache
 #+end_src
 


### PR DESCRIPTION
In https://github.com/conao3/files#make, the name is `imagemagic`, which seems to be a typo for `imagemagick`.

```
$ brew install imagemagic
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 2 taps (homebrew/core and homebrew/cask).
==> Updated Formulae
Updated 2 formulae.
==> New Casks
nota

==> Searching for similarly named formulae...
These similarly named formulae were found:
imagemagick ✔                                                                                          imagemagick@6
To install one of them, run (for example):
  brew install imagemagick ✔
Error: No available formula or cask with the name "imagemagic".
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.
==> Searching taps on GitHub...
Error: No formulae found in taps.
```